### PR TITLE
Add playfair cipher python program with example, test and documentation

### DIFF
--- a/code/python/README.md
+++ b/code/python/README.md
@@ -1,0 +1,45 @@
+### playfair_cipher.py
+ - Main functions :-
+    - `playfair_enc(key,pt)`
+        - _arguments_
+            - key **[reqd]**
+            - pt (_plaintext_) as a _string_ **[reqd]**
+        - _returns_
+            - list of strings each of length two
+    - `playfair_dec(key,ct)`
+        - _arguments_
+            - key **[reqd]**
+            - ct (_ciphertext_) as a _list_ of _strings_ i.e. the _ciphertext_ is split into chunks of length two(result of the `playfair_enc` function) **[reqd]**
+        - _returns_
+            - list of strings each of length two
+   > **NOTE** :
+   > - Both parameters passed i.e. key and plaintext/ciphertext have to be in lowercase. This can be done using the `str.lower()` function in python where `str` is the string variable you want to convert to lowercase.
+   >  - **[reqd]** states that the parameter/argument is a required one i.e. the function wouldn't work as desired if the **[reqd]** parameter is not passed
+   > - For the variable that is being returned, `''.join(list_of_strings)` could be used to just get a concatenated version of the strings. (It hasn't been implemented over here for brevity)
+
+ - **Eg:-**
+    ```python
+    from playfair_cipher import playfair_enc, playfair_dec
+    s = "man the wolf plugin for python in vscode is so cool"
+    k = "yeahbro"
+
+    encrypted_result = playfair_enc(k, s)
+    print(f'Encrypted result = {encrypted_result}')
+    print(f'Concatenated Encrypted result : {"".join(encrypted_result)}')
+
+    print('\n')
+
+    decrypted_result = playfair_dec(k, encrypted_result)
+    print(f'Decrypted result = {decrypted_result}')
+    print(f'Concatenated Decrypted result : {"".join(decrypted_result)}')
+    ```
+
+ - **Result :-**
+   ```
+   Encrypted result = ['kb', 'pn', 'ba', 'vc', 'md', 'si', 'yn', 'gp', 'rc', 'on', 'bn', 'ed', 'pg', 'pu', 'qd', 'cf', 'op', 'xh', 'pd', 'dc', 'di']
+   Concatenated Encrypted result : kbpnbavcmdsiyngprconbnedpgpuqdcfopxhpddcdi
+
+
+   Decrypted result = ['ma', 'nt', 'he', 'wo', 'lf', 'pl', 'ug', 'in', 'fo', 'rp', 'yt', 'ho', 'ni', 'nv', 'sc', 'od', 'ei', 'sx', 'so', 'co', 'ol']
+   Concatenated Decrypted result : manthewolfpluginforpythoninvscodeisxsocool
+   ```

--- a/code/python/README.md
+++ b/code/python/README.md
@@ -2,13 +2,13 @@
  - Main functions :-
     - `playfair_enc(key,pt)`
         - _arguments_
-            - key **[reqd]**
+            - key (_string_ (no spaces)) **[reqd]**
             - pt (_plaintext_) as a _string_ **[reqd]**
         - _returns_
             - list of strings each of length two
     - `playfair_dec(key,ct)`
         - _arguments_
-            - key **[reqd]**
+            - key (_string_ (no spaces)) **[reqd]**
             - ct (_ciphertext_) as a _list_ of _strings_ i.e. the _ciphertext_ is split into chunks of length two(result of the `playfair_enc` function) **[reqd]**
         - _returns_
             - list of strings each of length two

--- a/code/python/playfair_cipher.py
+++ b/code/python/playfair_cipher.py
@@ -1,0 +1,113 @@
+from pprint import pprint
+
+# taking "i"
+letter_one = 'i'
+to_replace = 'j'
+
+def create_matrix(key):
+    lalpha = [chr(i) for i in range(97, 97+26)]
+    lalpha.remove(to_replace)
+    key = key.replace(to_replace, letter_one)
+    lmat = list(dict.fromkeys(key))
+    for c in lalpha:
+        if c not in lmat:
+            lmat.append(c)
+    mat = [lmat[i*5:(i+1)*5] for i in range(0, 5)]
+    if __name__ == "__main__":
+        print('\nMatrix : -')
+        pprint(mat)
+    return mat
+
+def split_pt(pt):
+    ind = 0
+    pt_new = []
+    while(ind < len(pt)):
+        if(ind == len(pt)-1):
+            pt_new.append(f'{pt[ind]}x')
+            break
+        elif(pt[ind+1] == pt[ind]):
+            pt_new.append(f'{pt[ind]}x')
+            ind += 1
+            continue
+        else:
+            pt_new.append(pt[ind:ind+2])
+            ind += 2
+            continue
+    if __name__ == "__main__":
+        print(f'Split plain text : {pt_new}')
+    return(pt_new)
+
+def find(mat, s):
+    rno = 0
+    for r in mat:
+        if s in r:
+            r, c = rno, r.index(s)
+            return([r, c])
+        rno += 1
+
+def map_char(mat, flag, ch1_pos, ch2_pos):
+    r1, c1 = ch1_pos[0], ch1_pos[1]
+    r2, c2 = ch2_pos[0], ch2_pos[1]
+    if(r1 == r2):
+        ch1_n = mat[r1][(c1 + flag * 1) % 5]
+        ch2_n = mat[r2][(c2 + flag * 1) % 5]
+    elif(c1 == c2):
+        ch1_n = mat[(r1 + flag * 1) % 5][c1]
+        ch2_n = mat[(r2 + flag * 1) % 5][c2]
+    else:
+        diff = c1 - c2
+        ch1_n = mat[r1][c1 - diff]
+        ch2_n = mat[r2][c2 + diff]
+    return([ch1_n, ch2_n])
+
+def map_matrix(mat, ch1_pos, ch2_pos, operation):
+    if(operation == 'e'):
+        flag = 1
+    else:
+        flag = -1
+    ch1_n, ch2_n = map_char(mat, flag, ch1_pos, ch2_pos)
+    return([ch1_n, ch2_n])
+
+def encrypt(mat, pt):
+    ct = []
+    for ch in pt:
+        ch1_pos = find(mat, ch[0])
+        ch2_pos = find(mat, ch[1])
+        chs = map_matrix(mat, ch1_pos, ch2_pos, 'e')
+        ct.append(''.join(chs))
+    return(ct)
+
+def playfair_enc(key, pt):
+    mat = create_matrix(key)
+    pt = pt.replace(' ', '')
+    sec_pt = split_pt(pt)
+    ct = encrypt(mat, sec_pt)
+    return ct
+
+def decrypt(mat, ct):
+    pt = []
+    for ch in ct:
+        ch1_pos = find(mat, ch[0])
+        ch2_pos = find(mat, ch[1])
+        chs = map_matrix(mat, ch1_pos, ch2_pos, 'd')
+        pt.append(''.join(chs))
+    return(pt)
+
+def playfair_dec(key, ct):
+    mat = create_matrix(key)
+    sec_pt = decrypt(mat, ct)
+    return sec_pt
+
+def main():
+    print("Enter plain text :-")
+    pt = input("> ").lower()
+    print("Enter key :-")
+    key = input("> ").lower()
+    ct = playfair_enc(key, pt)
+    print(f'Encrypted text : {ct}')
+    sec_pt = playfair_dec(key, ct)
+    print(f'Decrypted text : {sec_pt}')
+
+
+if __name__ == "__main__":
+    main()

--- a/code/python/playfair_cipher_example.py
+++ b/code/python/playfair_cipher_example.py
@@ -1,0 +1,13 @@
+from playfair_cipher import playfair_enc, playfair_dec
+s = "man the wolf plugin for python in vscode is so cool"
+k = "yeahbro"
+
+encrypted_result = playfair_enc(k, s)
+print(f'Encrypted result = {encrypted_result}')
+print(f'Concatenated Encrypted result : {"".join(encrypted_result)}')
+
+print('\n')
+
+decrypted_result = playfair_dec(k, encrypted_result)
+print(f'Decrypted result = {decrypted_result}')
+print(f'Concatenated Decrypted result : {"".join(decrypted_result)}')

--- a/code/python/playfair_cipher_test.py
+++ b/code/python/playfair_cipher_test.py
@@ -1,0 +1,17 @@
+import unittest
+from playfair_cipher import playfair_enc, playfair_dec
+
+
+class TestPlayfairCipherMethods(unittest.TestCase):
+    s = "man the wolf plugin for python in vscode is so cool"
+    k = "yeahbro"
+    enc_res = ['kb', 'pn', 'ba', 'vc', 'md', 'si', 'yn', 'gp', 'rc', 'on', 'bn', 'ed', 'pg', 'pu', 'qd', 'cf', 'op', 'xh', 'pd', 'dc', 'di']
+    dec_res = ['ma', 'nt', 'he', 'wo', 'lf', 'pl', 'ug', 'in', 'fo', 'rp', 'yt', 'ho', 'ni', 'nv', 'sc', 'od', 'ei', 'sx', 'so', 'co', 'ol']
+    def test_playfair_enc(self):
+        self.assertEqual(playfair_enc(self.k, self.s), self.enc_res)
+
+    def test_playfair_dec(self):
+        self.assertEqual(playfair_dec(self.k, self.enc_res), self.dec_res)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Additions :-
 - **playfair_cipher.py**  ⇒ main playfair cipher program
 - **playfair_cipher_test.py** ⇒ unit test for playfair_cipher.py
 - **playfair_cipher_example.py** ⇒ example for playfair_cipher.py
 - **README.md** ⇒ documentation for playfair_cipher.py